### PR TITLE
Support for older FFMPEG versions

### DIFF
--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -68,7 +68,8 @@ InputVideoFile::InputVideoFile(std::string filename) :
     videoFrameCount_(0)
 {
 #if LIBAVFORMAT_VERSION_MAJOR < 58
-    // need to register all muxers, decoders, ... on ffmpeg versions before 58.x
+    // need to register all muxers, decoders, ... on ffmpeg versions before 58.x, see
+    // documentation and https://stackoverflow.com/questions/51604582/ffmpeg-and-docker-result-in-averror-invaliddata/51624309 
     av_register_all();
 #endif
 

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -67,6 +67,11 @@ InputVideoFile::InputVideoFile(std::string filename) :
     frame_(nullptr), draining_(false), lastError_(0),
     videoFrameCount_(0)
 {
+#if LIBAVFORMAT_VERSION_MAJOR < 58
+    // need to register all muxers, decoders, ... on ffmpeg versions before 58.x
+    av_register_all();
+#endif
+
     lastError_ = avformat_open_input(&formatContext_, filename_.c_str(), nullptr, nullptr);
     if (lastError_ < 0)
     {


### PR DESCRIPTION
For older versions (before 58.x) all the muxers, decoders, ... have to be registered manually.
An good explanation is found here: https://stackoverflow.com/questions/51604582/ffmpeg-and-docker-result-in-averror-invaliddata/51624309 and also in the FFMPEG docs.
If this is not done there is an error message like "Invalid data found when processing input" presented for some input codecs.