### PR TITLE
No longer crashes out if input video has no audio stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ if(UNIX)
 endif()
 
 if(WIN32)
-    set(CMAKE_LIBRARY_PATH "${PROJECT_SOURCE_DIR}/lib/ffmpeg-dev-windows/lib")
-    set(DERPERVIEW_FFMPEG_DLL_PATH "${PROJECT_SOURCE_DIR}/lib/ffmpeg-shared-windows/bin")
-    include_directories("${PROJECT_SOURCE_DIR}/lib/ffmpeg-dev-windows/include")
+    set(CMAKE_LIBRARY_PATH "${PROJECT_SOURCE_DIR}/lib/ffmpeg-windows/lib")
+    set(DERPERVIEW_FFMPEG_DLL_PATH "${PROJECT_SOURCE_DIR}/lib/ffmpeg-windows/bin")
+    include_directories("${PROJECT_SOURCE_DIR}/lib/ffmpeg-windows/include")
 endif()
 
 # try to find libswresample

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -27,7 +27,7 @@ derperview uses multiple threads to speed up processing. By default it uses 4, b
 
 - libav (the ffmpeg fork, not the libav one)
 
-Included in the binary releases, but you'll need to download the libs if you want to build from source. I'm currently building against Zeranoe's _ffmpeg-4.2.2-win64-shared_.
+Included in the binary releases, but you'll need to download the libs if you want to build from source. I'm currently building against Gyan Doshi's _ffmpeg-5.1.2-full_build-shared_ for Windows.
 
 ## Issues, Suggestions and Comments
 

--- a/ci-scripts/download-ffmpeg-windows.sh
+++ b/ci-scripts/download-ffmpeg-windows.sh
@@ -1,16 +1,14 @@
 #!/bin/sh
 
-FFMPEG_VERSION=4.2.2
+FFMPEG_VERSION=5.1.2
 
-mkdir -p ../lib
+mkdir -p ../lib/ffmpeg-windows
 pushd ../lib
 
-curl -O https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-${FFMPEG_VERSION}-win64-dev.zip
-unzip -o ffmpeg-${FFMPEG_VERSION}-win64-dev.zip
-mv ffmpeg-${FFMPEG_VERSION}-win64-dev ffmpeg-dev-windows
-
-curl -O https://ffmpeg.zeranoe.com/builds/win64/shared/ffmpeg-${FFMPEG_VERSION}-win64-shared.zip
-unzip -o ffmpeg-${FFMPEG_VERSION}-win64-shared.zip
-mv ffmpeg-${FFMPEG_VERSION}-win64-shared ffmpeg-shared-windows
+curl -O https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-${FFMPEG_VERSION}-full_build-shared.7z
+7z x -y ffmpeg-${FFMPEG_VERSION}-full_build-shared.7z
+mv ffmpeg-${FFMPEG_VERSION}-full_build-shared/lib/ ffmpeg-windows
+mv ffmpeg-${FFMPEG_VERSION}-full_build-shared/include/ ffmpeg-windows
+mv ffmpeg-${FFMPEG_VERSION}-full_build-shared/bin/ ffmpeg-windows
 
 popd

--- a/include/Video.hpp
+++ b/include/Video.hpp
@@ -26,7 +26,7 @@ namespace DerperView
 
         int64_t audioBitRate;
         int audioSampleRate;
-        uint64_t audioChannelLayout;
+        AVChannelLayout audioChannelLayout;
         int audioChannels;
         AVSampleFormat audioSampleFormat;
     };
@@ -55,7 +55,7 @@ namespace DerperView
         AVCodecContext *audioCodecContext_;
         int videoStreamIndex_;
         int audioStreamIndex_;
-        AVPacket packet_;
+        AVPacket *packet_;
         AVFrame *frame_;
         bool draining_;
         int videoFrameCount_;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,11 +8,11 @@ endif()
 
 if(WIN32)
     add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy 
-            "${DERPERVIEW_FFMPEG_DLL_PATH}/avcodec-58.dll" 
-            "${DERPERVIEW_FFMPEG_DLL_PATH}/avformat-58.dll" 
-            "${DERPERVIEW_FFMPEG_DLL_PATH}/avutil-56.dll" 
-            "${DERPERVIEW_FFMPEG_DLL_PATH}/swresample-3.dll"
+        COMMAND ${CMAKE_COMMAND} -E copy
+            "${DERPERVIEW_FFMPEG_DLL_PATH}/avcodec-59.dll"
+            "${DERPERVIEW_FFMPEG_DLL_PATH}/avformat-59.dll"
+            "${DERPERVIEW_FFMPEG_DLL_PATH}/avutil-57.dll"
+            "${DERPERVIEW_FFMPEG_DLL_PATH}/swresample-4.dll"
             "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>"
     )
 endif()

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -166,7 +166,8 @@ AVFrame *InputVideoFile::GetNextFrame()
             // Begin draining
             draining_ = true;
             lastError_ = avcodec_send_packet(videoCodecContext_, nullptr);
-            lastError_ = avcodec_send_packet(audioCodecContext_, nullptr);
+            if (audioCodecContext_ != nullptr)
+                lastError_ = avcodec_send_packet(audioCodecContext_, nullptr);
             return GetNextDrainFrame();
         }
         av_packet_unref(&packet_);
@@ -180,21 +181,27 @@ AVFrame *InputVideoFile::GetNextDrainFrame()
     lastError_ = avcodec_receive_frame(videoCodecContext_, frame_);
     if (lastError_ != AVERROR_EOF)
         return frame_;
-    lastError_ = avcodec_receive_frame(audioCodecContext_, frame_);
-    if (lastError_ != AVERROR_EOF)
-        return frame_;
+    if (audioCodecContext_ != nullptr)
+    {
+        lastError_ = avcodec_receive_frame(audioCodecContext_, frame_);
+        if (lastError_ != AVERROR_EOF)
+            return frame_;
+    }
     return nullptr;
 }
 
 VideoInfo InputVideoFile::GetVideoInfo()
 {
     VideoInfo v;
-    v.audioBitRate = audioCodecContext_->bit_rate;
-    v.audioChannels = audioCodecContext_->channels;
-    v.audioChannelLayout = audioCodecContext_->channel_layout;
-    v.audioSampleFormat = audioCodecContext_->sample_fmt;
-    v.audioSampleRate = audioCodecContext_->sample_rate;
-    v.audioTimeBase = audioCodecContext_->time_base;
+    if (audioCodecContext_ != nullptr)
+    {
+        v.audioBitRate = audioCodecContext_->bit_rate;
+        v.audioChannels = audioCodecContext_->channels;
+        v.audioChannelLayout = audioCodecContext_->channel_layout;
+        v.audioSampleFormat = audioCodecContext_->sample_fmt;
+        v.audioSampleRate = audioCodecContext_->sample_rate;
+        v.audioTimeBase = audioCodecContext_->time_base;
+    }
     v.bitRate = static_cast<int>(videoCodecContext_->bit_rate);
     v.frameRate = formatContext_->streams[videoStreamIndex_]->r_frame_rate;
     v.height = videoCodecContext_->height;
@@ -255,33 +262,36 @@ OutputVideoFile::OutputVideoFile(string filename, VideoInfo sourceInfo) :
     if (lastError_ < 0)
         return;
 
-    AVCodec *audioCodec = avcodec_find_encoder(formatContext_->oformat->audio_codec);
-    audioCodecContext_ = avcodec_alloc_context3(audioCodec);
-    audioStream_ = avformat_new_stream(formatContext_, audioCodec);
-
-    // Populate codec data. Most of it comes from the audio source.
-    // If the channel layout is missing, populate with a default based on number of channels
-    // (seen in sowt codec on Runcam 5 Orange)
-    audioCodecContext_->bit_rate = min(static_cast<int64_t>(128000), sourceInfo.audioBitRate);
-    audioCodecContext_->sample_rate = sourceInfo.audioSampleRate;
-    audioCodecContext_->sample_fmt = audioCodec->sample_fmts[0];
-    audioCodecContext_->channels = sourceInfo.audioChannels;
-    audioCodecContext_->channel_layout = av_get_default_channel_layout(audioCodecContext_->channels);
-    audioCodecContext_->time_base = sourceInfo.audioTimeBase;
-    audioStream_->time_base = audioCodecContext_->time_base;
-
-    opt = nullptr;
-    lastError_ = avcodec_open2(audioCodecContext_, audioCodec, &opt);
-    if (lastError_ < 0)
+    if (audioCodecContext_ != nullptr)
     {
-        cerr << "Error creating audio codec" << endl;
-        return;
-    }
-    av_dict_free(&opt);
+        AVCodec* audioCodec = avcodec_find_encoder(formatContext_->oformat->audio_codec);
+        audioCodecContext_ = avcodec_alloc_context3(audioCodec);
+        audioStream_ = avformat_new_stream(formatContext_, audioCodec);
 
-    lastError_ = avcodec_parameters_from_context(audioStream_->codecpar, audioCodecContext_);
-    if (lastError_ < 0)
-        return;
+        // Populate codec data. Most of it comes from the audio source.
+        // If the channel layout is missing, populate with a default based on number of channels
+        // (seen in sowt codec on Runcam 5 Orange)
+        audioCodecContext_->bit_rate = min(static_cast<int64_t>(128000), sourceInfo.audioBitRate);
+        audioCodecContext_->sample_rate = sourceInfo.audioSampleRate;
+        audioCodecContext_->sample_fmt = audioCodec->sample_fmts[0];
+        audioCodecContext_->channels = sourceInfo.audioChannels;
+        audioCodecContext_->channel_layout = av_get_default_channel_layout(audioCodecContext_->channels);
+        audioCodecContext_->time_base = sourceInfo.audioTimeBase;
+        audioStream_->time_base = audioCodecContext_->time_base;
+
+        opt = nullptr;
+        lastError_ = avcodec_open2(audioCodecContext_, audioCodec, &opt);
+        if (lastError_ < 0)
+        {
+            cerr << "Error creating audio codec" << endl;
+            return;
+        }
+        av_dict_free(&opt);
+
+        lastError_ = avcodec_parameters_from_context(audioStream_->codecpar, audioCodecContext_);
+        if (lastError_ < 0)
+            return;
+    }
 
     av_dump_format(formatContext_, 0, filename.c_str(), 1);
 
@@ -298,23 +308,26 @@ OutputVideoFile::OutputVideoFile(string filename, VideoInfo sourceInfo) :
     }
 
     // Create audio resampler, if needed
-    if (sourceInfo.audioSampleFormat != audioCodecContext_->sample_fmt)
+    if (audioCodecContext_ != nullptr)
     {
-         audioResampleContext_ = swr_alloc_set_opts(
-            nullptr,
-            audioCodecContext_->channel_layout, // Output channel layout
-            audioCodecContext_->sample_fmt, // Output sample format
-            audioCodecContext_->sample_rate, // Output sample rate
-            av_get_default_channel_layout(sourceInfo.audioChannels),
-            sourceInfo.audioSampleFormat,
-            sourceInfo.audioSampleRate,
-            0, nullptr
-        );
-
-        lastError_ = swr_init(audioResampleContext_);
-        if (lastError_ < 0)
+        if (sourceInfo.audioSampleFormat != audioCodecContext_->sample_fmt)
         {
-            cerr << "Could not set up audio format resampling: " << GetErrorString(lastError_) << endl;
+            audioResampleContext_ = swr_alloc_set_opts(
+                nullptr,
+                audioCodecContext_->channel_layout, // Output channel layout
+                audioCodecContext_->sample_fmt, // Output sample format
+                audioCodecContext_->sample_rate, // Output sample rate
+                av_get_default_channel_layout(sourceInfo.audioChannels),
+                sourceInfo.audioSampleFormat,
+                sourceInfo.audioSampleRate,
+                0, nullptr
+            );
+
+            lastError_ = swr_init(audioResampleContext_);
+            if (lastError_ < 0)
+            {
+                cerr << "Could not set up audio format resampling: " << GetErrorString(lastError_) << endl;
+            }
         }
     }
 }
@@ -438,14 +451,17 @@ void OutputVideoFile::Flush()
     }
 
     // Flush audio
-    avcodec_send_frame(audioCodecContext_, nullptr);
-    lastError_ = avcodec_receive_packet(audioCodecContext_, &packet);
-    while (lastError_ != AVERROR_EOF)
+    if (audioCodecContext_ != nullptr)
     {
-        av_packet_rescale_ts(&packet, audioCodecContext_->time_base, audioStream_->time_base);
-        packet.stream_index = audioStream_->index;
-        lastError_ = av_interleaved_write_frame(formatContext_, &packet);
+        avcodec_send_frame(audioCodecContext_, nullptr);
         lastError_ = avcodec_receive_packet(audioCodecContext_, &packet);
+        while (lastError_ != AVERROR_EOF)
+        {
+            av_packet_rescale_ts(&packet, audioCodecContext_->time_base, audioStream_->time_base);
+            packet.stream_index = audioStream_->index;
+            lastError_ = av_interleaved_write_frame(formatContext_, &packet);
+            lastError_ = avcodec_receive_packet(audioCodecContext_, &packet);
+        }
     }
 }
 


### PR DESCRIPTION
Also updates ffmpeg to from 4.2.2 to 5.1.2, moves out some deprecated functions and tidies up some of the dependency fetch scripts on Windows.